### PR TITLE
Allow NULL (Option<fn>) callback to create_event

### DIFF
--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -93,7 +93,7 @@ fn test_events(system_table: &SystemTable) -> Result<(), usize> {
     let simple_result = system_table.boot_services.create_event(
         EventType::empty(),
         TPL::Callback,
-        empty_callback,
+        None,
         &()
     );
     match simple_result {
@@ -134,7 +134,7 @@ fn test_events(system_table: &SystemTable) -> Result<(), usize> {
     let simple_result = system_table.boot_services.create_event(
         EventType::NOTIFY_SIGNAL,
         TPL::Callback,
-        echo_callback,
+        Some(echo_callback),
         &"callback message"
     );
     match simple_result {

--- a/src/boot_services/mod.rs
+++ b/src/boot_services/mod.rs
@@ -76,7 +76,7 @@ pub struct BootServices {
     pub _create_event: extern "win64" fn(
         event_type: EventType,
         notify_tpl: TPL,
-        notify_function: extern "win64" fn(event: &Event, context: *const ()),
+        notify_function: Option<extern "win64" fn(event: &Event, context: *const ())>,
         notify_context: *const (),
         event: &mut &Event
     ) -> Status,


### PR DESCRIPTION
UEFI allows passing a NULL NotifyFunction to CreateEvent, giving you a synchronous notification (good for the Timer) via WaitForEvent.